### PR TITLE
Added example for Adafruit ST7735 based TFTs

### DIFF
--- a/examples/LCDML_DISPLAYTYPE/LCDML_glcd_adafruit_st7735/LCDML_CONTROL.ino
+++ b/examples/LCDML_DISPLAYTYPE/LCDML_glcd_adafruit_st7735/LCDML_CONTROL.ino
@@ -1,0 +1,449 @@
+// =====================================================================
+//
+// CONTROL
+//
+// =====================================================================
+// *********************************************************************
+// *********************************************************************
+// content:
+// (0) Control over serial interface
+// (1) Control over one analog input 
+// (2) Control over 4 - 6 digital input pins (internal pullups enabled)
+// (3) Control over encoder (internal pullups enabled)
+// (4) Control with Keypad
+// (5) Control with an ir remote
+// (6) Control with a youstick
+// *********************************************************************
+
+#define _LCDML_CONTROL_cfg      0  
+
+
+// therory:
+// "#if" is a preprocessor directive and no error, look here:
+// (english) https://en.wikipedia.org/wiki/C_preprocessor
+// (german)  https://de.wikipedia.org/wiki/C-Pr%C3%A4prozessor
+
+
+// *********************************************************************
+// CONTROL TASK, DO NOT CHANGE
+// *********************************************************************
+void LCDML_BACK_setup(LCDML_BACKEND_control)      
+// *********************************************************************
+{
+  // call setup   
+  LCDML_CONTROL_setup();      
+}
+// backend loop
+boolean LCDML_BACK_loop(LCDML_BACKEND_control)
+{    
+  // call loop
+  LCDML_CONTROL_loop();
+
+  // go to next backend function and do not block it
+  return true;  
+}
+// backend stop stable
+void LCDML_BACK_stable(LCDML_BACKEND_control)
+{
+}
+
+
+
+
+// *********************************************************************
+// *************** (0) CONTROL OVER SERIAL INTERFACE *******************
+// *********************************************************************
+#if(_LCDML_CONTROL_cfg == 0)
+// settings
+  # define _LCDML_CONTROL_serial_enter           'e'
+  # define _LCDML_CONTROL_serial_up              'w'
+  # define _LCDML_CONTROL_serial_down            's'
+  # define _LCDML_CONTROL_serial_left            'a'
+  # define _LCDML_CONTROL_serial_right           'd'
+  # define _LCDML_CONTROL_serial_quit            'q'
+// *********************************************************************
+// setup
+void LCDML_CONTROL_setup()
+{
+}
+// *********************************************************************
+// loop
+void LCDML_CONTROL_loop()
+{
+  // check if new serial input is available  
+  if (Serial.available()) {
+    // read one char from input buffer   
+    switch (Serial.read())
+    {
+      case _LCDML_CONTROL_serial_enter:  LCDML_BUTTON_enter(); break;
+      case _LCDML_CONTROL_serial_up:     LCDML_BUTTON_up();    break;
+      case _LCDML_CONTROL_serial_down:   LCDML_BUTTON_down();  break;
+      case _LCDML_CONTROL_serial_left:   LCDML_BUTTON_left();  break;
+      case _LCDML_CONTROL_serial_right:  LCDML_BUTTON_right(); break;
+      case _LCDML_CONTROL_serial_quit:   LCDML_BUTTON_quit();  break;
+      default: break;
+    } 
+  }
+}
+// *********************************************************************
+// ******************************* END *********************************
+// *********************************************************************
+
+
+
+
+
+// *********************************************************************
+// *************** (1) CONTROL OVER ONE ANALOG PIN *********************
+// *********************************************************************
+#elif(_LCDML_CONTROL_cfg == 1)
+// settings
+  #define _LCDML_CONTROL_analog_pin              0
+  // when you did not use a button set the value to zero
+  #define _LCDML_CONTROL_analog_enter_min        850     // Button Enter
+  #define _LCDML_CONTROL_analog_enter_max        920  
+  #define _LCDML_CONTROL_analog_up_min           520     // Button Up
+  #define _LCDML_CONTROL_analog_up_max           590   
+  #define _LCDML_CONTROL_analog_down_min         700     // Button Down
+  #define _LCDML_CONTROL_analog_down_max         770   
+  #define _LCDML_CONTROL_analog_back_min         950     // Button Back
+  #define _LCDML_CONTROL_analog_back_max         1020   
+  #define _LCDML_CONTROL_analog_left_min         430     // Button Left
+  #define _LCDML_CONTROL_analog_left_max         500   
+  #define _LCDML_CONTROL_analog_right_min        610     // Button Right
+  #define _LCDML_CONTROL_analog_right_max        680
+// *********************************************************************
+// setup
+void LCDML_CONTROL_setup()
+{
+}
+// *********************************************************************
+// loop
+void LCDML_CONTROL_loop()
+{
+  // check debounce timer  
+  if((millis() - g_LCDML_DISP_press_time) >= _LCDML_DISP_cfg_button_press_time) {
+    g_LCDML_DISP_press_time = millis(); // reset debounce timer
+    
+    uint16_t value = analogRead(_LCDML_CONTROL_analog_pin);  // analogpin for keypad
+    
+    if (value >= _LCDML_CONTROL_analog_enter_min && value <= _LCDML_CONTROL_analog_enter_max) { LCDML_BUTTON_enter(); }
+    if (value >= _LCDML_CONTROL_analog_up_min    && value <= _LCDML_CONTROL_analog_up_max)    { LCDML_BUTTON_up();    }
+    if (value >= _LCDML_CONTROL_analog_down_min  && value <= _LCDML_CONTROL_analog_down_max)  { LCDML_BUTTON_down();  }
+    if (value >= _LCDML_CONTROL_analog_left_min  && value <= _LCDML_CONTROL_analog_left_max)  { LCDML_BUTTON_left();  }
+    if (value >= _LCDML_CONTROL_analog_right_min && value <= _LCDML_CONTROL_analog_right_max) { LCDML_BUTTON_right(); }
+    if (value >= _LCDML_CONTROL_analog_back_min  && value <= _LCDML_CONTROL_analog_back_max)  { LCDML_BUTTON_quit();  }
+  }
+}
+// *********************************************************************
+// ******************************* END *********************************
+// *********************************************************************
+
+
+
+
+
+
+// *********************************************************************
+// *************** (2) CONTROL OVER DIGITAL PINS ***********************
+// *********************************************************************
+#elif(_LCDML_CONTROL_cfg == 2)
+// settings
+  #define _LCDML_CONTROL_digital_low_active      0    // (0 = low active (pullup), 1 = high active (pulldown) button
+                                                      // http://playground.arduino.cc/CommonTopics/PullUpDownResistor
+  #define _LCDML_CONTROL_digital_enable_quit     1
+  #define _LCDML_CONTROL_digital_enable_lr       1
+  #define _LCDML_CONTROL_digital_enter           8    
+  #define _LCDML_CONTROL_digital_up              9
+  #define _LCDML_CONTROL_digital_down            10
+  #define _LCDML_CONTROL_digital_quit            11
+  #define _LCDML_CONTROL_digital_left            12
+  #define _LCDML_CONTROL_digital_right           13
+// *********************************************************************
+// setup
+void LCDML_CONTROL_setup()
+{
+  // init buttons
+  pinMode(_LCDML_CONTROL_digital_enter      , INPUT_PULLUP);
+  pinMode(_LCDML_CONTROL_digital_up         , INPUT_PULLUP);
+  pinMode(_LCDML_CONTROL_digital_down       , INPUT_PULLUP);  
+  # if(_LCDML_CONTROL_digital_enable_quit == 1)
+    pinMode(_LCDML_CONTROL_digital_quit     , INPUT_PULLUP);
+  # endif
+  # if(_LCDML_CONTROL_digital_enable_lr == 1)
+    pinMode(_LCDML_CONTROL_digital_left     , INPUT_PULLUP);
+    pinMode(_LCDML_CONTROL_digital_right    , INPUT_PULLUP);
+  # endif
+}
+// *********************************************************************
+// loop
+void LCDML_CONTROL_loop()
+{
+  #if(_LCDML_CONTROL_digital_low_active == 1)
+  #  define _LCDML_CONTROL_digital_a !
+  #else
+  #  define _LCDML_CONTROL_digital_a
+  #endif
+  
+  uint8_t but_stat = 0x00;
+  
+  bitWrite(but_stat, 0, _LCDML_CONTROL_digital_a(digitalRead(_LCDML_CONTROL_digital_enter)));
+  bitWrite(but_stat, 1, _LCDML_CONTROL_digital_a(digitalRead(_LCDML_CONTROL_digital_up)));
+  bitWrite(but_stat, 2, _LCDML_CONTROL_digital_a(digitalRead(_LCDML_CONTROL_digital_down)));
+  #if(_LCDML_CONTROL_digital_enable_quit == 1)
+  bitWrite(but_stat, 3, _LCDML_CONTROL_digital_a(digitalRead(_LCDML_CONTROL_digital_quit)));
+  #endif
+  #if(_LCDML_CONTROL_digital_enable_lr == 1)
+  bitWrite(but_stat, 4, _LCDML_CONTROL_digital_a(digitalRead(_LCDML_CONTROL_digital_left)));
+  bitWrite(but_stat, 5, _LCDML_CONTROL_digital_a(digitalRead(_LCDML_CONTROL_digital_right)));
+  #endif  
+  
+  if (but_stat > 0) {
+    if((millis() - g_LCDML_DISP_press_time) >= _LCDML_DISP_cfg_button_press_time) {
+      g_LCDML_DISP_press_time = millis(); // reset press time
+    
+      if (bitRead(but_stat, 0)) { LCDML_BUTTON_enter(); }
+      if (bitRead(but_stat, 1)) { LCDML_BUTTON_up();    }
+      if (bitRead(but_stat, 2)) { LCDML_BUTTON_down();  }
+      if (bitRead(but_stat, 3)) { LCDML_BUTTON_quit();  }
+      if (bitRead(but_stat, 4)) { LCDML_BUTTON_left();  }
+      if (bitRead(but_stat, 5)) { LCDML_BUTTON_right(); }        
+    }    
+  }
+}
+// *********************************************************************
+// ******************************* END *********************************
+// *********************************************************************
+
+
+
+
+
+
+// *********************************************************************
+// *************** (3) CONTROL WITH ENCODER ****************************
+// *********************************************************************
+#elif(_LCDML_CONTROL_cfg == 3)
+// settings
+  #define _LCDML_CONTROL_encoder_pin_a           10 // pin encoder b
+  #define _LCDML_CONTROL_encoder_pin_b           11 // pin encoder a
+  #define _LCDML_CONTROL_encoder_pin_button      12 // pin taster
+  #define _LCDML_CONTROL_encoder_high_active     0  // (0 = low active (pullup), 1 = high active (pulldown)) button
+                                                      // // http://playground.arduino.cc/CommonTopics/PullUpDownResistor
+// global defines
+  uint8_t  g_LCDML_CONTROL_encoder_t_prev = 0;
+  uint8_t  g_LCDML_CONTROL_encoder_a_prev = 0;
+
+// *********************************************************************
+// setup
+void LCDML_CONTROL_setup()
+{
+  // set encoder update intervall time 
+  LCDML_BACK_dynamic_setLoopTime(LCDML_BACKEND_control, 5UL);  // 5ms 
+
+  // init pins  
+  pinMode(_LCDML_CONTROL_encoder_pin_a      , INPUT_PULLUP);
+  pinMode(_LCDML_CONTROL_encoder_pin_b      , INPUT_PULLUP);
+  pinMode(_LCDML_CONTROL_encoder_pin_button , INPUT_PULLUP); 
+}
+// *********************************************************************
+// loop
+void LCDML_CONTROL_loop()
+{    
+  // read encoder status
+  unsigned char a = digitalRead(_LCDML_CONTROL_encoder_pin_a);
+  unsigned char b = digitalRead(_LCDML_CONTROL_encoder_pin_b);
+  unsigned char t = digitalRead(_LCDML_CONTROL_encoder_pin_button);
+  
+  // change button status if high and low active are switched
+  if (_LCDML_CONTROL_encoder_high_active == 1) {
+    t != t;
+  }
+  
+  // check encoder status and set control menu
+  if (!a && g_LCDML_CONTROL_encoder_a_prev) {
+    g_LCDML_CONTROL_encoder_t_prev = 1;
+    
+    if (!b) { LCDML_BUTTON_up();   }
+    else    { LCDML_BUTTON_down(); }            
+  } 
+  else {
+    // check button press time for enter
+    if((millis() - g_LCDML_DISP_press_time) >= _LCDML_DISP_cfg_button_press_time) {
+      g_LCDML_DISP_press_time = millis(); // reset button press time
+      
+      // press button once
+      if (!t && g_LCDML_CONTROL_encoder_t_prev == 0) {          
+          LCDML_BUTTON_enter();          
+      } 
+      else {
+        g_LCDML_CONTROL_encoder_t_prev = 0;
+      }
+    }      
+  }
+  g_LCDML_CONTROL_encoder_a_prev = a;  // set new encoder status 
+  
+}
+// *********************************************************************
+// ******************************* END *********************************
+// *********************************************************************
+
+
+
+
+
+// *********************************************************************
+// *************** (4) CONTROL WITH A KEYPAD ***************************
+// *********************************************************************
+#elif(_LCDML_CONTROL_cfg == 4)
+// include
+  // more information under http://playground.arduino.cc/Main/KeypadTutorial
+  #include <Keypad.h>
+// settings
+  #define _LCDML_CONTROL_keypad_rows 4 // Four rows
+  #define _LCDML_CONTROL_keypad_cols 3 // Three columns
+// global vars
+  char keys[_LCDML_CONTROL_keypad_rows][_LCDML_CONTROL_keypad_cols] = { 
+    {'1','2','3'},
+    {'4','5','6'},
+    {'7','8','9'},
+    {'#','0','*'}
+  };  
+  byte rowPins[_LCDML_CONTROL_keypad_rows] = { 9, 8, 7, 6 };  // Connect keypad COL0, COL1 and COL2 to these Arduino pins.
+  byte colPins[_LCDML_CONTROL_keypad_cols] = { 12, 11, 10 };  // Create the Keypad
+// objects
+  Keypad kpd = Keypad( makeKeymap(keys), rowPins, colPins, _LCDML_CONTROL_keypad_rows, _LCDML_CONTROL_keypad_cols );
+// *********************************************************************
+// setup
+void LCDML_CONTROL_setup()
+{
+}
+// *********************************************************************
+// loop
+void LCDML_CONTROL_loop()
+{    
+  char key = kpd.getKey();
+  if(key)  // Check for a valid key.
+  {
+    switch (key)
+    {
+      case '#': LCDML_BUTTON_enter(); break;
+      case '2': LCDML_BUTTON_up();    break;
+      case '8': LCDML_BUTTON_down();  break;
+      case '4': LCDML_BUTTON_left();  break;
+      case '6': LCDML_BUTTON_right(); break;
+      case '*': LCDML_BUTTON_quit();  break;
+      default: break;       
+    }
+  } 
+}
+// *********************************************************************
+// ******************************* END *********************************
+// *********************************************************************
+
+
+// *********************************************************************
+// *************** (5) CONTROL WITH IR REMOTE ***************************
+// *********************************************************************
+#elif(_LCDML_CONTROL_cfg == 5)
+	// ir include (this lib have to be installed) 
+	#include <IRremote.h>
+	// ir global vars
+	int RECV_PIN = 11; 
+	// ir objects
+	IRrecv irrecv(RECV_PIN);
+	decode_results results;
+  
+// *********************************************************************
+// setup (nothing change here)
+void LCDML_CONTROL_setup()
+{
+	irrecv.enableIRIn(); // Start the receiver
+}
+// *********************************************************************
+// loop
+// change in this function the ir values to your values
+void LCDML_CONTROL_loop()
+{  
+	if (irrecv.decode(&results))
+	{
+		// comment this line out, to check the correct code 
+		//Serial.println(results.value, HEX);
+    
+		// in this switch case you have to change the value 0x...1 to the correct ir code
+		switch (results.value)
+		{
+			case 0x00000001: LCDML_BUTTON_enter(); break;  
+			case 0x00000002: LCDML_BUTTON_up();    break;
+			case 0x00000003: LCDML_BUTTON_down();  break;
+			case 0x00000004: LCDML_BUTTON_left();  break;
+			case 0x00000005: LCDML_BUTTON_right(); break;
+			case 0x00000006: LCDML_BUTTON_quit();  break;
+			default: break;       
+		}
+	} 
+}
+// *********************************************************************
+// ******************************* END *********************************
+// *********************************************************************
+
+
+
+/ *********************************************************************
+// *************** (6) CONTROL OVER JOYSTICK *********************
+// *********************************************************************
+#elif(_LCDML_CONTROL_cfg == 6)
+	// settings
+	#define _LCDML_CONTROL_analog_pinx A0
+	#define _LCDML_CONTROL_analog_piny A1
+	#define _LCDML_CONTROL_digitalread 33 //don't work with u8glib
+
+	// when you did not use a button set the value to zero
+	#define _LCDML_CONTROL_analog_up_min 612 // Button Up
+	#define _LCDML_CONTROL_analog_up_max 1023
+	#define _LCDML_CONTROL_analog_down_min 0 // Button Down
+	#define _LCDML_CONTROL_analog_down_max 412
+	#define _LCDML_CONTROL_analog_left_min 612 // Button Left
+	#define _LCDML_CONTROL_analog_left_max 1023
+	#define _LCDML_CONTROL_analog_right_min 0 // Button Right
+	#define _LCDML_CONTROL_analog_right_max 412
+// *********************************************************************
+// setup
+void LCDML_CONTROL_setup()
+{	
+	pinMode (_LCDML_CONTROL_digitalread, INPUT);
+}
+// *********************************************************************
+// loop
+void LCDML_CONTROL_loop()
+{
+	// check debounce timer
+	if((millis() - g_LCDML_DISP_press_time) >= _LCDML_DISP_cfg_button_press_time) {
+		g_LCDML_DISP_press_time = millis(); // reset debounce timer
+
+		uint16_t valuex = analogRead(_LCDML_CONTROL_analog_pinx);  // analogpinx
+		uint16_t valuey = analogRead(_LCDML_CONTROL_analog_piny);  // analogpinx
+		uint16_t valuee = digitalRead(_LCDML_CONTROL_digitalread);  //digitalpinenter
+
+		
+		if (valuey >= _LCDML_CONTROL_analog_up_min && valuey <= _LCDML_CONTROL_analog_up_max) { LCDML_BUTTON_up(); }		// up
+		if (valuey >= _LCDML_CONTROL_analog_down_min && valuey <= _LCDML_CONTROL_analog_down_max) { LCDML_BUTTON_down(); }	// down
+		if (valuex >= _LCDML_CONTROL_analog_left_min && valuex <= _LCDML_CONTROL_analog_left_max) { LCDML_BUTTON_left(); } 	// left
+		if (valuex >= _LCDML_CONTROL_analog_right_min && valuex <= _LCDML_CONTROL_analog_right_max) { LCDML_BUTTON_right(); }	// right
+		
+		if(valuee == true) {LCDML_BUTTON_enter();}	// enter
+
+		// back buttons have to be included as menuitem 
+		// lock at the examle LCDML_back_button
+
+	}
+}
+// *********************************************************************
+// ******************************* END *********************************
+// *********************************************************************
+
+
+#else
+  #error _LCDML_CONTROL_cfg is not defined or not in range
+#endif
+

--- a/examples/LCDML_DISPLAYTYPE/LCDML_glcd_adafruit_st7735/LCDML_DISP.ino
+++ b/examples/LCDML_DISPLAYTYPE/LCDML_glcd_adafruit_st7735/LCDML_DISP.ino
@@ -1,0 +1,88 @@
+// =====================================================================
+//
+// Output function
+//
+// =====================================================================
+
+/* ******************************************************************** */
+void LCDML_lcd_menu_display()
+/* ******************************************************************** */
+{
+
+	// clear lcd
+	display.fillScreen(_LCDML_ADAFRUIT_BACKGROUND_COLOR);
+	// set text color / Textfarbe setzen
+	display.setTextColor(_LCDML_ADAFRUIT_TEXT_COLOR);  
+	// set text size / Textgroesse setzen
+	display.setTextSize(_LCDML_ADAFRUIT_FONT_SIZE);
+  
+  
+	if (LCDML_DISP_update()) {
+
+		// init vars
+		uint8_t n_max = (LCDML.getChilds() >= _LCDML_ADAFRUIT_rows) ? ((_LCDML_ADAFRUIT_rows > _LCDML_ADAFRUIT_rows_max) ? _LCDML_ADAFRUIT_rows : _LCDML_ADAFRUIT_rows_max) : (LCDML.getChilds());
+    
+		// display rows and cursor
+		for (uint8_t n = 0; n < n_max; n++)
+		{
+		// set cursor
+		if (n == LCDML.getCursorPos()) {
+			display.setCursor(0, _LCDML_ADAFRUIT_FONT_H * (n));
+			display.println("X");        
+		}
+	  
+	  
+
+		// set content
+		// with content id you can add special content to your static menu or replace the content
+		// the content_id contains the id wich is set on main tab for a menuitem
+        switch(LCDML.content_id[n])
+		{		 
+			//case 0: // dynamic content			
+			//	display.setCursor(0, _LCDML_ADAFRUIT_FONT_H * (n));
+			//	display.println("var_datetime");
+			//	break;
+		
+			default: // static content
+				display.setCursor(0, _LCDML_ADAFRUIT_FONT_H * (n));
+				display.println(LCDML.content[n]);
+				break;				
+		}
+	          
+    }
+
+    // display scrollbar when more content as rows available 
+    if (LCDML.getChilds() > n_max) {
+
+      // set frame for scrollbar
+	  display.drawRect(_LCDML_ADAFRUIT_lcd_w - _LCDML_ADAFRUIT_scrollbar_w, 0,_LCDML_ADAFRUIT_scrollbar_w,_LCDML_ADAFRUIT_lcd_h, _LCDML_ADAFRUIT_TEXT_COLOR); 
+	  
+	  // calculate scrollbar length
+      uint8_t scrollbar_block_length = LCDML.getChilds() - n_max;
+      scrollbar_block_length = _LCDML_ADAFRUIT_lcd_h / (scrollbar_block_length + _LCDML_DISP_rows);
+
+      //set scrollbar
+	  // hier muss du mal schauen wie du blöcke einfügen kannst, bei der u8glib geht das wie unten angezeigt, bei deiner lib weis ich das nicht
+      if (LCDML.getCursorPosAbs() == 0) {                                   // top position     (min)
+        //u8g.drawBox(_LCDML_ADAFRUIT_lcd_w - (_LCDML_ADAFRUIT_scrollbar_w-1), 1                                                    , (_LCDML_ADAFRUIT_scrollbar_w-2)  , scrollbar_block_length);
+      } 
+      else if (LCDML.getCursorPosAbs() == (LCDML.getChilds())) {            // bottom position  (max)         
+        //u8g.drawBox(_LCDML_ADAFRUIT_lcd_w - (_LCDML_ADAFRUIT_scrollbar_w-1), _LCDML_ADAFRUIT_lcd_h - scrollbar_block_length            , (_LCDML_ADAFRUIT_scrollbar_w-2)  , scrollbar_block_length);
+      } 
+      else {                                                                // between top and bottom
+        //u8g.drawBox(_LCDML_ADAFRUIT_lcd_w - (_LCDML_ADAFRUIT_scrollbar_w-1), (scrollbar_block_length * LCDML.getCursorPosAbs() + 1),(_LCDML_ADAFRUIT_scrollbar_w-2)  , scrollbar_block_length);
+      }
+    }
+    
+  }
+  
+  
+
+  // reinit some vars
+  LCDML_DISP_update_end();
+}
+
+// lcd clear
+void LCDML_lcd_menu_clear()
+{
+}

--- a/examples/LCDML_DISPLAYTYPE/LCDML_glcd_adafruit_st7735/LCDML_FUNC_BACKEND.ino
+++ b/examples/LCDML_DISPLAYTYPE/LCDML_glcd_adafruit_st7735/LCDML_FUNC_BACKEND.ino
@@ -1,0 +1,33 @@
+/* ===================================================================== *
+ *                                                                       *
+ * BACKEND SYSTEM                                                        *
+ *                                                                       *
+ * ===================================================================== *
+ * every "backend function" needs three functions 
+ * - void LCDML_BACK_setup(..func_name..)    
+ * - void LCDML_BACK_loop(..func_name..)     
+ * - void LCDML_BACK_stable(..func_name..)
+ *
+ * - every BACKEND function can be stopped and started
+ * EXAMPLE CODE:
+    void LCDML_BACK_setup(LCDML_BACKEND_control)
+    {
+      // setup
+      // is called only if it is started or restartet (reset+start)
+    }
+    
+    boolean LCDML_BACK_loop(LCDML_BACKEND_control)
+    {    
+      // runs in loop
+      
+     
+      return false;  
+    }
+    
+    void LCDML_BACK_stable(LCDML_BACKEND_control)
+    {
+      // stable stop
+      // is called when a backend function is stopped with stopStable  
+    }
+ * ===================================================================== *
+ */

--- a/examples/LCDML_DISPLAYTYPE/LCDML_glcd_adafruit_st7735/LCDML_FUNC_DISP.ino
+++ b/examples/LCDML_DISPLAYTYPE/LCDML_glcd_adafruit_st7735/LCDML_FUNC_DISP.ino
@@ -1,0 +1,226 @@
+/* ===================================================================== *
+ *                                                                       *
+ * DISPLAY SYSTEM                                                        *
+ *                                                                       *
+ * ===================================================================== *
+ * every "disp menu function" needs three functions 
+ * - void LCDML_DISP_setup(func_name)    
+ * - void LCDML_DISP_loop(func_name)     
+ * - void LCDML_DISP_loop_end(func_name)
+ *
+ * EXAMPLE CODE:
+    void LCDML_DISP_setup(..menu_func_name..) 
+    {
+      // setup
+      // is called only if it is started
+
+      // starts a trigger event for the loop function every 100 millisecounds
+      LCDML_DISP_triggerMenu(100);  
+    }
+    
+    void LCDML_DISP_loop(..menu_func_name..)
+    { 
+      // loop
+      // is called when it is triggert
+      // - with LCDML_DISP_triggerMenu( millisecounds ) 
+      // - with every button status change
+
+      // check if any button is presed (enter, up, down, left, right)
+      if(LCDML_BUTTON_checkAny()) {         
+        LCDML_DISP_funcend();
+      } 
+    }
+    
+    void LCDML_DISP_loop_end(..menu_func_name..)
+    {
+      // loop end
+      // this functions is ever called when a DISP function is quit
+      // you can here reset some global vars or do nothing  
+    } 
+ * ===================================================================== * 
+ */
+
+// *********************************************************************
+void LCDML_DISP_setup(LCDML_FUNC_information)
+// *********************************************************************
+{
+  // setup function
+  // clear lcd
+  display.fillScreen(_LCDML_ADAFRUIT_BACKGROUND_COLOR); 
+  // set text color / Textfarbe setzen
+  display.setTextColor(_LCDML_ADAFRUIT_TEXT_COLOR);  
+  // set text size / Textgroesse setzen
+  display.setTextSize(_LCDML_ADAFRUIT_FONT_SIZE);
+
+  display.setCursor(0, _LCDML_ADAFRUIT_FONT_H * 0); // line 0
+  display.println(F("To close this")); 
+  display.setCursor(0, _LCDML_ADAFRUIT_FONT_H * 1); // line 1
+  display.println(F("function press")); 
+  display.setCursor(0, _LCDML_ADAFRUIT_FONT_H * 2); // line 2
+  display.println(F("any button or use")); 
+  display.setCursor(0, _LCDML_ADAFRUIT_FONT_H * 3); // line 3
+  display.println(F("back button")); 
+   
+}
+
+void LCDML_DISP_loop(LCDML_FUNC_information) 
+{
+  // loop function, can be run in a loop when LCDML_DISP_triggerMenu(xx) is set
+  // the quit button works in every DISP function without any checks; it starts the loop_end function   
+  if(LCDML_BUTTON_checkAny()) { // check if any button is presed (enter, up, down, left, right)
+    // LCDML_DISP_funcend calls the loop_end function
+    LCDML_DISP_funcend();
+  } 
+}
+
+void LCDML_DISP_loop_end(LCDML_FUNC_information)
+{
+  // this functions is ever called when a DISP function is quit
+  // you can here reset some global vars or do nothing    
+}  
+
+
+// *********************************************************************
+uint8_t g_func_timer_info = 0;  // time counter (global variable)
+unsigned long g_timer_1 = 0;    // timer variable (globale variable)
+void LCDML_DISP_setup(LCDML_FUNC_timer_info)
+// *********************************************************************
+{
+  // setup function
+  char buf[20];
+  sprintf (buf, "wait %d secounds", 10);
+
+  // clear lcd
+  display.fillScreen(_LCDML_ADAFRUIT_BACKGROUND_COLOR); 
+  // set text color / Textfarbe setzen
+  display.setTextColor(_LCDML_ADAFRUIT_TEXT_COLOR);  
+  // set text size / Textgroesse setzen
+  display.setTextSize(_LCDML_ADAFRUIT_FONT_SIZE);
+
+  display.setCursor(0, _LCDML_ADAFRUIT_FONT_H * 0); // line 0
+  display.println(buf); 
+  display.setCursor(0, _LCDML_ADAFRUIT_FONT_H * 1); // line 1
+  display.println(F("or press back button")); 
+  
+     
+  g_func_timer_info = 10;       // reset and set timer    
+  LCDML_DISP_triggerMenu(100);  // starts a trigger event for the loop function every 100 millisecounds
+}
+
+void LCDML_DISP_loop(LCDML_FUNC_timer_info)
+{ 
+  // loop function, can be run in a loop when LCDML_DISP_triggerMenu(xx) is set
+  // the quit button works in every DISP function without any checks; it starts the loop_end function 
+  
+  // this function is called every 100 millisecounds
+  
+  // this timer checks every 1000 millisecounds if it is called
+  if((millis() - g_timer_1) >= 1000) {
+    g_timer_1 = millis();   
+    g_func_timer_info--;                // increment the value every secound
+    char buf[20];
+    sprintf (buf, "wait %d secounds", g_func_timer_info);
+    
+    // clear lcd
+    display.fillScreen(_LCDML_ADAFRUIT_BACKGROUND_COLOR); 
+    // set text color / Textfarbe setzen
+    display.setTextColor(_LCDML_ADAFRUIT_TEXT_COLOR);  
+    // set text size / Textgroesse setzen
+    display.setTextSize(_LCDML_ADAFRUIT_FONT_SIZE);
+  
+    display.setCursor(0, _LCDML_ADAFRUIT_FONT_H * 0); // line 0
+    display.println(buf); 
+    display.setCursor(0, _LCDML_ADAFRUIT_FONT_H * 1); // line 1
+    display.println(F("or press back button")); 
+    
+  }
+  
+  // reset the initscreen timer
+  LCDML_DISP_resetIsTimer();
+  
+  // this function can only be ended when quit button is pressed or the time is over
+  // check if the function ends normaly
+  if (g_func_timer_info <= 0)
+  {
+    // end function for callback
+    LCDML_DISP_funcend();  
+  }   
+}
+
+void LCDML_DISP_loop_end(LCDML_FUNC_timer_info) 
+{
+  // this functions is ever called when a DISP function is quit
+  // you can here reset some global vars or do nothing
+}
+
+// *********************************************************************
+uint8_t g_button_value = 0; // button value counter (global variable)
+void LCDML_DISP_setup(LCDML_FUNC_p2)
+// *********************************************************************
+{ 
+  // setup function
+  // print lcd content
+  char buf[17];
+  sprintf (buf, "count: %d of 3", 0); 
+
+  // clear lcd
+  display.fillScreen(_LCDML_ADAFRUIT_BACKGROUND_COLOR); 
+  // set text color / Textfarbe setzen
+  display.setTextColor(_LCDML_ADAFRUIT_TEXT_COLOR);  
+  // set text size / Textgroesse setzen
+  display.setTextSize(_LCDML_ADAFRUIT_FONT_SIZE);
+
+  display.setCursor(0, _LCDML_ADAFRUIT_FONT_H * 0); // line 0
+  display.println(F("press a or w button")); 
+  display.setCursor(0, _LCDML_ADAFRUIT_FONT_H * 1); // line 1
+  display.println(buf); 
+  
+
+  // Reset Button Value
+  g_button_value = 0; 
+}
+
+void LCDML_DISP_loop(LCDML_FUNC_p2)
+{
+  // loop function, can be run in a loop when LCDML_DISP_triggerMenu(xx) is set
+  // the quit button works in every DISP function without any checks; it starts the loop_end function 
+  
+  if (LCDML_BUTTON_checkAny()) // check if any button is pressed (enter, up, down, left, right)
+  {
+    if (LCDML_BUTTON_checkLeft() || LCDML_BUTTON_checkUp()) // check if button left is pressed
+    {
+      LCDML_BUTTON_resetLeft(); // reset the left button
+      LCDML_BUTTON_resetUp(); // reset the left button
+      g_button_value++;
+      
+      // update lcd content
+      char buf[17];
+      sprintf (buf, "count: %d of 3", g_button_value);
+      
+      // clear lcd
+      display.fillScreen(_LCDML_ADAFRUIT_BACKGROUND_COLOR);
+      // set text color / Textfarbe setzen
+      display.setTextColor(_LCDML_ADAFRUIT_TEXT_COLOR);  
+      // set text size / Textgroesse setzen
+      display.setTextSize(_LCDML_ADAFRUIT_FONT_SIZE);
+    
+      display.setCursor(0, _LCDML_ADAFRUIT_FONT_H * 0); // line 0
+      display.println(F("press a or w button")); 
+      display.setCursor(0, _LCDML_ADAFRUIT_FONT_H * 1); // line 1
+      display.println(buf); 
+             
+    }    
+  }
+  
+  // check if button count is three
+  if (g_button_value >= 3) {
+    // end function for callback
+    LCDML_DISP_funcend();   
+  } 
+}
+
+void LCDML_DISP_loop_end(LCDML_FUNC_p2) 
+{
+  // this functions is ever called when a DISP function is quit
+  // you can here reset some global vars or do nothing
+}

--- a/examples/LCDML_DISPLAYTYPE/LCDML_glcd_adafruit_st7735/LCDML_glcd_adafruit_st7735.ino
+++ b/examples/LCDML_DISPLAYTYPE/LCDML_glcd_adafruit_st7735/LCDML_glcd_adafruit_st7735.ino
@@ -1,0 +1,172 @@
+// ============================================================                                                            
+// Example:     LCDML: use adafruit i2c display ssd1306                           
+// ============================================================
+// Autor:       Nils Feldkämper, Markus Rudel
+// Last update: 18.01.2017
+// License:     MIT                                     
+// ============================================================ 
+// Descripton:  
+// ============================================================ 
+
+  // include libs
+  #include <LCDMenuLib.h>
+  #include <SPI.h>
+  #include <Wire.h>
+  #include <Adafruit_GFX.h>    // Core graphics library
+  #include <Adafruit_ST7735.h> // Hardware-specific library
+
+  
+  // lib config
+  #define _LCDML_DISP_cfg_button_press_time          200    // button press time in ms
+
+// *********************************************************************
+// Adafruit TFT_ST7735
+// *********************************************************************
+// https://learn.adafruit.com/1-8-tft-display/graphics-library
+  
+  #define _ADAFRUIT_I2C_ADR    0x3C
+  #define _LCDML_ADAFRUIT_TEXT_COLOR       ST7735_WHITE
+  #define _LCDML_ADAFRUIT_BACKGROUND_COLOR ST7735_BLACK 
+  
+  #define _LCDML_ADAFRUIT_FONT_SIZE   1   
+  #define _LCDML_ADAFRUIT_FONT_W      (6*_LCDML_ADAFRUIT_FONT_SIZE)             // font width 
+  #define _LCDML_ADAFRUIT_FONT_H      (8*_LCDML_ADAFRUIT_FONT_SIZE)             // font heigt 
+  
+  // settings for u8g lib and lcd
+  #define _LCDML_ADAFRUIT_lcd_w       128            // lcd width
+  #define _LCDML_ADAFRUIT_lcd_h       160             // lcd height
+ 
+  
+  
+  // TFT display and SD card will share the hardware SPI interface.
+  // Hardware SPI pins are specific to the Arduino board type and
+  // cannot be remapped to alternate pins.  For Arduino Uno,
+  // Duemilanove, etc., pin 11 = MOSI, pin 12 = MISO, pin 13 = SCK.
+  #define TFT_CS  10  // Chip select line for TFT display
+  #define TFT_RST  9  // Reset line for TFT (or see below...)
+  #define TFT_DC   8  // Data/command line for TFT
+
+  #define SD_CS    4  // Chip select line for SD card
+  Adafruit_ST7735 display = Adafruit_ST7735(TFT_CS, TFT_DC, TFT_RST);
+  
+
+
+  // nothing change here
+  #define _LCDML_ADAFRUIT_cols_max    (_LCDML_ADAFRUIT_lcd_w/_LCDML_ADAFRUIT_FONT_W)  
+  #define _LCDML_ADAFRUIT_rows_max    (_LCDML_ADAFRUIT_lcd_h/_LCDML_ADAFRUIT_FONT_H) 
+
+  // rows and cols 
+  // when you use more rows or cols as allowed change in LCDMenuLib.h the define "_LCDML_DISP_cfg_max_rows" and "_LCDML_DISP_cfg_max_string_length"
+  // the program needs more ram with this changes
+  #define _LCDML_ADAFRUIT_cols        20                   // max cols
+  #define _LCDML_ADAFRUIT_rows        _LCDML_ADAFRUIT_rows_max  // max rows 
+
+
+  // scrollbar width
+  #define _LCDML_ADAFRUIT_scrollbar_w 6  // scrollbar width  
+
+
+  // old defines with new content
+  #define _LCDML_DISP_cols      _LCDML_ADAFRUIT_cols
+  #define _LCDML_DISP_rows      _LCDML_ADAFRUIT_rows  
+
+
+// *********************************************************************
+// LCDML MENU/DISP
+// *********************************************************************
+  // create menu
+  // menu element count - last element id
+  // this value must be the same as the last menu element
+  #define _LCDML_DISP_cnt    16
+  
+  // LCDML_root        => layer 0 
+  // LCDML_root_X      => layer 1 
+  // LCDML_root_X_X    => layer 2 
+  // LCDML_root_X_X_X  => layer 3 
+  // LCDML_root_... 	 => layer ... 
+  
+  // LCDMenuLib_add(id, group, prev_layer_element, new_element_num, lang_char_array, callback_function)
+  LCDML_DISP_init(_LCDML_DISP_cnt);
+  LCDML_DISP_add      (0  , _LCDML_G1  , LCDML_root        , 1  , "Information"        , LCDML_FUNC_information);
+  LCDML_DISP_add      (1  , _LCDML_G1  , LCDML_root        , 2  , "Time info"          , LCDML_FUNC_timer_info);
+  LCDML_DISP_add      (2  , _LCDML_G1  , LCDML_root        , 3  , "Settings"           , LCDML_FUNC);
+  LCDML_DISP_add      (3  , _LCDML_G1  , LCDML_root_3      , 1  , "Change value"       , LCDML_FUNC);
+  LCDML_DISP_add      (4  , _LCDML_G1  , LCDML_root_3      , 2  , "Something"          , LCDML_FUNC);
+  LCDML_DISP_add      (5  , _LCDML_G1  , LCDML_root        , 4  , "Program"            , LCDML_FUNC);
+  LCDML_DISP_add      (6  , _LCDML_G1  , LCDML_root_4      , 1  , "Program 1"          , LCDML_FUNC);
+  LCDML_DISP_add      (7  , _LCDML_G1  , LCDML_root_4_1    , 1  , "P1 start"           , LCDML_FUNC);
+  LCDML_DISP_add      (8  , _LCDML_G1  , LCDML_root_4_1    , 2  , "Settings"           , LCDML_FUNC);
+  LCDML_DISP_add      (9  , _LCDML_G1  , LCDML_root_4_1_2  , 1  , "Warm"               , LCDML_FUNC);
+  LCDML_DISP_add      (10 , _LCDML_G1  , LCDML_root_4_1_2  , 2  , "Long"               , LCDML_FUNC);
+  LCDML_DISP_add      (11 , _LCDML_G1  , LCDML_root_4      , 2  , "Program 2"          , LCDML_FUNC_p2);
+  LCDML_DISP_add      (12 , _LCDML_G1  , LCDML_root        , 5  , "Mode"               , LCDML_FUNC);
+  LCDML_DISP_add      (13 , _LCDML_G1  , LCDML_root        , 6  , "Serial No."         , LCDML_FUNC);
+  LCDML_DISP_add      (14 , _LCDML_G1  , LCDML_root        , 7  , "Display Type"       , LCDML_FUNC);
+  LCDML_DISP_add      (15 , _LCDML_G1  , LCDML_root        , 8  , "Something 1"        , LCDML_FUNC);
+  LCDML_DISP_add      (16 , _LCDML_G1  , LCDML_root        , 9  , "Something 2"        , LCDML_FUNC);
+  LCDML_DISP_createMenu(_LCDML_DISP_cnt);
+
+
+
+// ********************************************************************* 
+// LCDML BACKEND (core of the menu, do not change here anything yet)
+// ********************************************************************* 
+  // define backend function  
+  #define _LCDML_BACK_cnt    1  // last backend function id
+  
+  LCDML_BACK_init(_LCDML_BACK_cnt);
+  LCDML_BACK_new_timebased_dynamic (0  , ( 20UL )         , _LCDML_start  , LCDML_BACKEND_control);
+  LCDML_BACK_new_timebased_dynamic (1  , ( 10000000UL )   , _LCDML_stop   , LCDML_BACKEND_menu);
+  LCDML_BACK_create();
+
+
+
+// *********************************************************************
+// SETUP
+// *********************************************************************
+  void setup()
+  {  
+    // serial init; only be needed if serial control is used 
+    while(!Serial);                    // wait until serial ready
+    Serial.begin(9600);                // start serial    
+    Serial.println(F(_LCDML_VERSION)); // only for examples
+      
+    // Enable all items with _LCDML_G1
+    LCDML_DISP_groupEnable(_LCDML_G1); // enable group 1
+  
+    // clear lcd
+    display.fillScreen(_LCDML_ADAFRUIT_BACKGROUND_COLOR);
+    // set text color / Textfarbe setzen
+    display.setTextColor(_LCDML_ADAFRUIT_TEXT_COLOR);  
+    // set text size / Textgroesse setzen
+    display.setTextSize(_LCDML_ADAFRUIT_FONT_SIZE);
+    display.setCursor(0, _LCDML_ADAFRUIT_FONT_H * (3));
+    display.println("LCDMenuLib v2.1.4 alpha");
+    
+    delay(1000);    
+  
+    // LCDMenu Setup
+    LCDML_setup(_LCDML_BACK_cnt);  
+  }
+
+// *********************************************************************
+// LOOP
+// *********************************************************************
+  void loop()
+  { 
+    // this function must called here, do not delete it
+    LCDML_run(_LCDML_priority); 
+  }
+
+
+
+
+// *********************************************************************
+// check some errors - do not change here anything
+// *********************************************************************
+# if(_LCDML_DISP_rows > _LCDML_ADAFRUIT_rows_max)
+# error change value of _LCDML_ADAFRUIT_rows_max in LCDMenuLib.h
+# endif
+# if(_LCDML_DISP_cols > _LCDML_DISP_cfg_max_string_length)
+# error change value of _LCDML_DISP_cfg_max_string_length in LCDMenuLib.h
+# endif

--- a/examples/LCDML_DISPLAYTYPE/LCDML_glcd_adafruit_st7735/LCDML_glcd_adafruit_st7735.ino
+++ b/examples/LCDML_DISPLAYTYPE/LCDML_glcd_adafruit_st7735/LCDML_glcd_adafruit_st7735.ino
@@ -133,9 +133,10 @@
       
     // Enable all items with _LCDML_G1
     LCDML_DISP_groupEnable(_LCDML_G1); // enable group 1
-  
+
+    SPI.begin();
     // clear lcd
-    display.fillScreen(_LCDML_ADAFRUIT_BACKGROUND_COLOR);
+    display.initR(INITR_BLACKTAB);
     // set text color / Textfarbe setzen
     display.setTextColor(_LCDML_ADAFRUIT_TEXT_COLOR);  
     // set text size / Textgroesse setzen

--- a/examples/LCDML_DISPLAYTYPE/LCDML_glcd_adafruit_st7735/LCDML_glcd_adafruit_st7735.ino
+++ b/examples/LCDML_DISPLAYTYPE/LCDML_glcd_adafruit_st7735/LCDML_glcd_adafruit_st7735.ino
@@ -24,7 +24,6 @@
 // *********************************************************************
 // https://learn.adafruit.com/1-8-tft-display/graphics-library
   
-  #define _ADAFRUIT_I2C_ADR    0x3C
   #define _LCDML_ADAFRUIT_TEXT_COLOR       ST7735_WHITE
   #define _LCDML_ADAFRUIT_BACKGROUND_COLOR ST7735_BLACK 
   
@@ -135,8 +134,25 @@
     LCDML_DISP_groupEnable(_LCDML_G1); // enable group 1
 
     SPI.begin();
+
+    // Our supplier changed the 1.8" display slightly after Jan 10, 2012
+    // so that the alignment of the TFT had to be shifted by a few pixels
+    // this just means the init code is slightly different. Check the
+    // color of the tab to see which init code to try. If the display is
+    // cut off or has extra 'random' pixels on the top & left, try the
+    // other option!
+    // If you are seeing red and green color inversion, use Black Tab
+  
+    // If your TFT's plastic wrap has a Black Tab, use the following:
+    display.initR(INITR_BLACKTAB);   // initialize a ST7735S chip, black tab
+    // If your TFT's plastic wrap has a Red Tab, use the following:
+    //tft.initR(INITR_REDTAB);   // initialize a ST7735R chip, red tab
+    // If your TFT's plastic wrap has a Green Tab, use the following:
+    //tft.initR(INITR_GREENTAB); // initialize a ST7735R chip, green tab
+
     // clear lcd
-    display.initR(INITR_BLACKTAB);
+    display.fillScreen(_LCDML_ADAFRUIT_BACKGROUND_COLOR);
+    
     // set text color / Textfarbe setzen
     display.setTextColor(_LCDML_ADAFRUIT_TEXT_COLOR);  
     // set text size / Textgroesse setzen


### PR DESCRIPTION
Hi Nils,

I'm currently trying to adopt your cool library for my screen. It's a ST7735 based TFT which is also sold by adafruit but is also available as clones. It is 1.8" with 128x160px and a SD card slot. The provided example writes the menu on the screen but has no way of input. I'll probably use the joystick example from dreep (https://github.com/Jomelo/LCDMenuLib/issues/19), although I have a working Library which does something very similar.

Let me know if I should add a way to support the joystick.

Cheers
Markus